### PR TITLE
DM-50772: Prevent publication of duplicate configuration events.

### DIFF
--- a/doc/news/DM-50772.bugfix.txt
+++ b/doc/news/DM-50772.bugfix.txt
@@ -1,0 +1,1 @@
+Prevented publication of duplicate configuration events.


### PR DESCRIPTION
Handles a problem in which multiple copies of the lowerAhuConfiguration event were being published.