### PR TITLE
OSW-712: When publishing, wait for confirmation that the message was published.

### DIFF
--- a/doc/news/OSW-712.feature.rst
+++ b/doc/news/OSW-712.feature.rst
@@ -1,0 +1,1 @@
+Wait for confirmation that the message was published.

--- a/python/lsst/ts/hvac/base_mqtt_client.py
+++ b/python/lsst/ts/hvac/base_mqtt_client.py
@@ -53,7 +53,9 @@ class BaseMqttClient(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def publish_mqtt_message(self, topic: str, payload: str) -> bool:
+    async def publish_mqtt_message(
+        self, topic: str, payload: str, qos: int = 1, timeout: float = 5.0
+    ) -> bool:
         """Publishes the specified payload to the specified topic on the MQTT
         server.
 
@@ -63,10 +65,17 @@ class BaseMqttClient(ABC):
             The topic to publish to.
         payload: `str`
             The payload to publish.
+        qos: `int`
+            The MQTT QoS parameter to be used in sending the message:
+             * 0 = at most once
+             * 1 = at least once
+             * 2 = exactly once
+        timeout: `float`
+            Time after which to return a failure, in seconds.
 
         Returns
         -------
         is_published: `bool`
-            For now False gets returned since this functionality is disabled.
+            True if the message was published successfully.
         """
         raise NotImplementedError()

--- a/python/lsst/ts/hvac/csc.py
+++ b/python/lsst/ts/hvac/csc.py
@@ -698,6 +698,6 @@ class HvacCsc(salobj.BaseCsc):
 
     async def _send_command(self, topic: str, payload: typing.Any) -> bool:
         assert self.mqtt_client is not None
-        was_published = self.mqtt_client.publish_mqtt_message(topic, payload)
+        was_published = await self.mqtt_client.publish_mqtt_message(topic, payload)
         self.log.info(f"{topic=} with {payload=} was published? {was_published}")
         return was_published

--- a/python/lsst/ts/hvac/simulator/sim_client.py
+++ b/python/lsst/ts/hvac/simulator/sim_client.py
@@ -100,13 +100,11 @@ class SimClient(BaseMqttClient):
         for topic in TOPICS_ALWAYS_ENABLED:
             self.topics_enabled[topic] = True
 
-    def publish_mqtt_message(self, topic: str, payload: str) -> bool:
-        """Publish the specified payload to the specified topic.
-
-        A topic represents an MQTT topic including the command to execute.
-        Two types of commands exist in the real MQTT server: enable commands
-        and configuration commands. The enable commands accept a boolean and
-        the configuration commands accept a float.
+    async def publish_mqtt_message(
+        self, topic: str, payload: str, qos: int = 1, timeout: float = 5.0
+    ) -> bool:
+        """Publishes the specified payload to the specified topic on the MQTT
+        server.
 
         Parameters
         ----------
@@ -115,6 +113,13 @@ class SimClient(BaseMqttClient):
         payload: `str`
             The payload to publish. This corresponds to a boolean for the
             enable commands and a float for the configuration commands.
+        qos: `int`
+            The MQTT QoS parameter to be used in sending the message:
+             * 0 = at most once
+             * 1 = at least once
+             * 2 = exactly once
+        timeout: `float`
+            Time after which to return a failure, in seconds.
 
         Returns
         -------

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import asyncio
 import logging
 import unittest
 from unittest import mock
@@ -43,7 +44,64 @@ class MqttClientTestCase(unittest.IsolatedAsyncioTestCase):
         mqtt_client.on_message(mqtt_client, "", msg)
         assert len(mqtt_client.msgs) == 1
 
-        assert mqtt_client.publish_mqtt_message(topic="", payload="")
+        assert await mqtt_client.publish_mqtt_message(topic="", payload="")
 
         await mqtt_client.disconnect()
         assert not mqtt_client.connected
+
+    @mock.patch("paho.mqtt.client.Client")
+    async def test_mqtt_client_success(self, mock_client: mock.MagicMock) -> None:
+        log = mock.MagicMock()
+        mqtt_client = MqttClient(host="127.0.0.1", port=5000, log=log)
+        mqtt_client.client = mock.MagicMock()
+
+        msg_info = mock.MagicMock()
+        msg_info.mid = 54321
+        msg_info.is_published.return_value = True
+        mqtt_client.client.publish = mock.MagicMock()
+        mqtt_client.client.publish.return_value = msg_info
+
+        publish_task = asyncio.create_task(
+            mqtt_client.publish_mqtt_message("some/topic", "payload", timeout=10.0)
+        )
+
+        await asyncio.sleep(0.05)
+        assert len(mqtt_client.pub_ack_events) == 1
+        mqtt_client.on_publish(
+            client=mqtt_client.client,
+            userdata=None,
+            mid=msg_info.mid,
+            reason_code=mqtt.ReasonCode(mqtt.PacketTypes.PUBACK),
+            properties=mqtt.Properties(mqtt.PacketTypes.PUBACK),
+        )
+
+        result = await publish_task
+        assert result is True
+        assert len(mqtt_client.pub_ack_events) == 0
+        assert (
+            mock.call(
+                "Timeout while sending message with topic='some/topic' and payload='payload'."
+            )
+            not in mqtt_client.log.debug.call_args_list
+        )
+
+    @mock.patch("paho.mqtt.client.Client")
+    async def test_mqtt_client_timeout(self, mock_client: mock.MagicMock) -> None:
+        log = mock.MagicMock()
+        mqtt_client = MqttClient(host="127.0.0.1", port=5000, log=log)
+        mqtt_client.client = mock.MagicMock()
+
+        msg_info = mock.MagicMock()
+        msg_info.mid = 12345
+        msg_info.is_published.return_value = False
+        mqtt_client.client.publish = mock.MagicMock()
+        mqtt_client.client.publish.return_value = msg_info
+
+        result = await mqtt_client.publish_mqtt_message(
+            "some/topic", "payload", timeout=0.1
+        )
+        assert not result
+        assert len(mqtt_client.pub_ack_events) == 0
+        mqtt_client.log.debug.assert_any_call(
+            "Timeout while sending message with topic='some/topic' and payload='payload'."
+        )

--- a/tests/test_sim_client.py
+++ b/tests/test_sim_client.py
@@ -158,7 +158,7 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
                     f"Encountered variable {var} of type {type(data)} with value {data} in topic {topic}"
                 )
 
-    def enable_topic(self, topic: str) -> None:
+    async def enable_topic(self, topic: str) -> None:
         """Enable the topic by sending True to the enable command.
 
         Parameters
@@ -168,9 +168,9 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
         """
         command = topic + "/" + "COMANDO_ENCENDIDO_LSST"
         value = "true"
-        self.mqtt_client.publish_mqtt_message(command, value)
+        await self.mqtt_client.publish_mqtt_message(command, value)
 
-    def disable_topic(self, topic: str) -> None:
+    async def disable_topic(self, topic: str) -> None:
         """Disable the topic by sending False to the enable command.
 
         Parameters
@@ -180,7 +180,7 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
         """
         command = topic + "/" + "COMANDO_ENCENDIDO_LSST"
         value = "false"
-        self.mqtt_client.publish_mqtt_message(command, value)
+        await self.mqtt_client.publish_mqtt_message(command, value)
 
     def determine_expected_state(self, topic: str) -> dict[str, typing.Any]:
         """Determine the expected state of the topic by looping over each
@@ -254,13 +254,13 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
         for topic in topics:
             if topic not in TOPICS_ALWAYS_ENABLED:
                 self.verify_topic_disabled(topic)
-                self.enable_topic(topic)
+                await self.enable_topic(topic)
 
             expected_state = self.determine_expected_state(topic)
             self.verify_topic_state(topic, expected_state)
 
             if topic not in TOPICS_ALWAYS_ENABLED:
-                self.disable_topic(topic)
+                await self.disable_topic(topic)
                 self.verify_topic_disabled(topic)
 
     async def test_config(self) -> None:
@@ -275,7 +275,7 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
 
                 # Enable the topic otherwise telemetry doesn't get
                 # published.
-                self.enable_topic(topic.value)
+                await self.enable_topic(topic.value)
                 mqtt_state = self.collect_mqtt_state()
                 # Verify that the corresponding telemetry items have the
                 # values as sent in the configurastion command.
@@ -297,4 +297,4 @@ class SimClientTestCase(unittest.IsolatedAsyncioTestCase):
 
                 self.log.info(mqtt_state)
                 # Disable the topic again.
-                self.disable_topic(topic.value)
+                await self.disable_topic(topic.value)


### PR DESCRIPTION
* Added code in `publish_mqtt_message` to set up an event and wait for it
* Several methods that were synchronous before are now asynchronous
* Some new unit tests